### PR TITLE
Use correct icon if there isn't one in the notification payload

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -161,7 +161,7 @@ public class RNPushNotificationHelper {
         if (smallIcon != null) {
             smallIconResId = res.getIdentifier(smallIcon, "mipmap", packageName);
         } else {
-            smallIconResId = res.getIdentifier("ic_notification", "mipmap", packageName);
+            smallIconResId = res.getIdentifier("ic_stat_name", "drawable", packageName);
         }
 
         if (smallIconResId == 0) {

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -151,19 +151,26 @@ public class RNPushNotificationHelper {
             getAlarmManager().set(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
         }
     }
-    
+
     private int getIconResourceId(Bundle bundle){
         String smallIcon = bundle.getString("smallIcon");
+        int smallIconResId;
         Resources res = context.getResources();
         String packageName = context.getPackageName();
-        int smallIconResId = 0;
 
         if (smallIcon != null) {
             smallIconResId = res.getIdentifier(smallIcon, "mipmap", packageName);
         } else {
-            smallIconResId = res.getIdentifier("ic_stat_name", "drawable", packageName);
+            smallIconResId = res.getIdentifier("ic_notification", "mipmap", packageName);
         }
 
+        if (smallIconResId == 0) {
+            smallIconResId = res.getIdentifier("ic_launcher", "mipmap", packageName);
+
+            if (smallIconResId == 0) {
+                smallIconResId = android.R.drawable.ic_dialog_info;
+            }
+        }
         return smallIconResId;
     }
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -151,26 +151,19 @@ public class RNPushNotificationHelper {
             getAlarmManager().set(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
         }
     }
-
+    
     private int getIconResourceId(Bundle bundle){
         String smallIcon = bundle.getString("smallIcon");
-        int smallIconResId;
         Resources res = context.getResources();
         String packageName = context.getPackageName();
+        int smallIconResId = 0;
 
         if (smallIcon != null) {
             smallIconResId = res.getIdentifier(smallIcon, "mipmap", packageName);
         } else {
-            smallIconResId = res.getIdentifier("ic_notification", "mipmap", packageName);
+            smallIconResId = res.getIdentifier("ic_stat_name", "drawable", packageName);
         }
 
-        if (smallIconResId == 0) {
-            smallIconResId = res.getIdentifier("ic_launcher", "mipmap", packageName);
-
-            if (smallIconResId == 0) {
-                smallIconResId = android.R.drawable.ic_dialog_info;
-            }
-        }
         return smallIconResId;
     }
 


### PR DESCRIPTION
FIXES apthletic/rivalbet-mobile#1729

Time spent: 1 hours

<img width="430" alt="Screen Shot 2020-06-18 at 6 35 45 pm" src="https://user-images.githubusercontent.com/47466735/85010205-f4e9c200-b1a2-11ea-8939-a91e4f5aeb66.png">
