### PR TITLE
Support for generic notification bundling

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -406,7 +406,7 @@ public class RNPushNotificationHelper {
             }
 
             notificationManager.notify(0, summaryBuilder.build());
-            
+
         } catch (Exception e) {
             Log.e(LOG_TAG, "failed to send push notification", e);
         }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -20,7 +20,6 @@ import org.json.JSONException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -406,6 +406,7 @@ public class RNPushNotificationHelper {
             }
 
             notificationManager.notify(0, summaryBuilder.build());
+            
         } catch (Exception e) {
             Log.e(LOG_TAG, "failed to send push notification", e);
         }


### PR DESCRIPTION
FIXES https://github.com/apthletic/rivalbet-mobile/issues/3036

Time spent: 3 hours

Sample notification payload:

```
"data": {
    "notification_type": "2",
    "wager_id": "27122",
    "navigation": {
      "route": "wager",
      "params": {
        "wager_id": 27122
      }
    },
    "bundle_id": "1574706845",     <--- notifications can be grouped by this ID
    "title": "'title'",
    "message": "'message' 3",
    "bundle_title": "'bundle_title'"
  }
```

Must have the following to be grouped:
`bundle_id`
`message`
`title`

The following is optional:
`bundle_title`

Demo with placeholders showing where values go:
![rb-bundle-notifs](https://user-images.githubusercontent.com/47466735/104414460-6c11f800-55c4-11eb-98ed-e62081acb741.gif)

Supports up to 5 messages, before being cropped with a message indicating how many more messages were received:
<img width="450" alt="Screen Shot 2021-01-13 at 5 22 10 pm" src="https://user-images.githubusercontent.com/47466735/104414168-e3935780-55c3-11eb-8ad0-f96657017236.png">

List will show latest messages at top.

Single screenshot

![image](https://user-images.githubusercontent.com/72950483/104517762-bccc3400-564a-11eb-9db3-7af1fed5c9b3.png)


