### PR TITLE
Support older Android phones + don't `notify` twice

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -218,6 +218,7 @@ public class RNPushNotificationHelper {
             final int smallIconResId = getIconResourceId(bundle);
             String notificationIdString = bundle.getString("id");
             final int notificationID = Integer.parseInt(notificationIdString);
+            boolean isSingleNotification = false;
 
             final String title = bundle.getString("title");
             String notificationType = bundle.getString("notification_type");
@@ -396,16 +397,18 @@ public class RNPushNotificationHelper {
                     .setSmallIcon(smallIconResId)
                     .setContentTitle(title)
                     .setContentText(message)
-                    .setStyle(notifStyle)
                     .setVibrate(new long[]{0, DEFAULT_VIBRATION})
                     .setAutoCancel(bundle.getBoolean("autoCancel", true));
                 notificationBuilder.setContentIntent(pendingIntent);
 
                 // LP: is a single message
                 notificationManager.notify(notificationID, notificationBuilder.build());
+                isSingleNotification = true;
             }
 
-            notificationManager.notify(0, summaryBuilder.build());
+            if (!isSingleNotification) {
+                notificationManager.notify(0, summaryBuilder.build());
+            }
 
         } catch (Exception e) {
             Log.e(LOG_TAG, "failed to send push notification", e);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -392,11 +392,11 @@ public class RNPushNotificationHelper {
 
                 NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mContext,
                     NOTIFICATION_CHANNEL_ID)
-                    .setGroup(APP_BUNDLE_ID)
                     .setExtras(extras)
                     .setSmallIcon(smallIconResId)
                     .setContentTitle(title)
                     .setContentText(message)
+                    .setStyle(notifStyle)
                     .setVibrate(new long[]{0, DEFAULT_VIBRATION})
                     .setAutoCancel(bundle.getBoolean("autoCancel", true));
                 notificationBuilder.setContentIntent(pendingIntent);

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -218,7 +218,6 @@ public class RNPushNotificationHelper {
             final int smallIconResId = getIconResourceId(bundle);
             String notificationIdString = bundle.getString("id");
             final int notificationID = Integer.parseInt(notificationIdString);
-            boolean isSingleNotification = false;
 
             final String title = bundle.getString("title");
             String notificationType = bundle.getString("notification_type");
@@ -357,7 +356,7 @@ public class RNPushNotificationHelper {
                 if (bundleTitle != null && !bundleTitle.isEmpty()) {
                     notifStyle.setSummaryText(bundleTitle);
                 }
-                
+
                 int extraNotificationCount = existingMessages.size() - MAX_GROUPED_NOTIFICATIONS;
 
                 for (int index = existingMessages.size() - 1; index >= 0; index--) {
@@ -403,13 +402,7 @@ public class RNPushNotificationHelper {
 
                 // LP: is a single message
                 notificationManager.notify(notificationID, notificationBuilder.build());
-                isSingleNotification = true;
             }
-
-            if (!isSingleNotification) {
-                notificationManager.notify(0, summaryBuilder.build());
-            }
-
         } catch (Exception e) {
             Log.e(LOG_TAG, "failed to send push notification", e);
         }


### PR DESCRIPTION
FIXES https://github.com/apthletic/rivalbet-mobile/issues/3670

Time spent: 1 hours

On a Samsung S7 with ringtone volume you can hear the notification twice and on the screen it glitches because it's showing one then quickly showing the next one.  This PR also fixes this.

Was able to replicate the original issue https://github.com/apthletic/rivalbet-mobile/issues/3670 by running the app on a simulator with the same O.S. version.  After the change it is working.

 - [x] Tested on Android phone with same OS level (API 23) as the original issue raised
 - [x] Tested on Android phone with OS level (API 26)
 - [x] Tested on newer phone with OS level (API 29) to make sure it doesn't impact what we already have working